### PR TITLE
Fix several issues with RPC secret embedding code

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,12 +11,13 @@ if [ ! -f $conf_path/aria2.conf ]; then
 fi
 
 if [ -n "$RPC_SECRET" ]; then
-    printf '\nrpc-secret=%s\n' "${RPC_SECRET}" >>$conf_path/aria2.conf
+    sed -i '/^rpc-secret=/d' $conf_path/aria2.conf
+    printf 'rpc-secret=%s\n' "${RPC_SECRET}" >>$conf_path/aria2.conf
 
     if [ -n "$EMBED_RPC_SECRET" ]; then
-        echo "Emdedding RPC secret into ariang Web UI"
-        RPC_SECRET_BASE64=$(echo -n "${RPC_SECRET}" | base64)
-        sed -i 's/secret:\"\"/secret:\"'"${RPC_SECRET_BASE64}"'\"/g' $ariang_js_path
+        echo "Embedding RPC secret into ariang Web UI"
+        RPC_SECRET_BASE64=$(echo -n "${RPC_SECRET}" | base64 -w 0)
+        sed -i 's,secret:"[^"]*",secret:"'"${RPC_SECRET_BASE64}"'",g' $ariang_js_path
     fi
 fi
 


### PR DESCRIPTION
 - Delete existing `rpc-secret` value from the config file. Previously, when the container was restarted, the secret was endlessly appended (along with extra blank lines)
 - Change sed replacement to use a comma for the delimiter, as base64 values may contain `/` characters
 - Add `-w 0` to base64 command to prevent corruption on long secret values from the output being wrapped at 76 columns
 - Fix to remove existing secret from javascript to cater for when the secret has changed
 - Fix typo in message