### PR TITLE
delete environment variable ARIA2RPCPORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ docker run -d \
     -v /CONFIG_DIR:/aria2/conf \
     -e PUID=1000 \
     -e PGID=1000 \
-    -e ARIA2RPCPORT=443 \
     -e RPC_SECRET=NOBODYKNOWSME \
     hurlenko/aria2-ariang
 ```
@@ -92,7 +91,6 @@ services:
       - PUID=1000
       - PGID=1000
       - RPC_SECRET=secret
-      - ARIA2RPCPORT=443
     restart: always
 ```
 
@@ -131,7 +129,6 @@ location / {
 - `EMBED_RPC_SECRET` - INSECURE: embeds `RPC_SECRET` into web ui js code. This allows you to skip entering the secret but everyone who has access to the webui will be able to see it. Only use this with some sort of authentication (e.g. basic auth)
 - `BASIC_AUTH_USERNAME` - username for basic auth
 - `BASIC_AUTH_PASSWORD` - password for basic auth
-- `ARIA2RPCPORT` - The port that will be used for rpc calls to aria2. Usually you want to set it to the port your website is running on. For example if your AriaNg instance is accessible on `https://ariang.mysite.com` you need to set `ARIA2RPCPORT` to `443` (default https port), otherwise AriaNg won't be able to access aria2 rpc running on the default port `8080`. You can set the port in the web ui by going to `AriaNg Settings` > `Rpc` tab > `Aria2 RPC Address` field, and changing the default rpc port to whatever you need, but this has to be done per browser.
 
 > Note, both `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` must be set in order to enable basic authentication.
 

--- a/patchs/0001-RPC.patch
+++ b/patchs/0001-RPC.patch
@@ -1,0 +1,66 @@
+From b98c68d13b120d2cd2bf83a4ec4d146909e294bc Mon Sep 17 00:00:00 2001
+From: FindlayFeng <i@fengch.me>
+Date: Sat, 24 Jun 2023 20:33:53 +0800
+Subject: [PATCH] =?UTF-8?q?=E4=BF=AE=E6=94=B9=20RPC=E8=BF=9E=E6=8E=A5?=
+ =?UTF-8?q?=E7=9A=84=E9=BB=98=E8=AE=A4=E5=80=BC?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: FindlayFeng <i@fengch.me>
+---
+ src/scripts/services/ariaNgSettingService.js | 31 +++++++++++++++++---
+ 1 file changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/src/scripts/services/ariaNgSettingService.js b/src/scripts/services/ariaNgSettingService.js
+index 2d9b633..2a6f818 100644
+--- a/src/scripts/services/ariaNgSettingService.js
++++ b/src/scripts/services/ariaNgSettingService.js
+@@ -134,6 +134,31 @@
+             return ariaNgConstants.defaultHost;
+         };
+ 
++        var getDefaultRpcProtocol = function () {
++            if (isInsecureProtocolDisabled()) {
++                return ariaNgConstants.defaultSecureProtocol;
++            }
++
++            return "http";
++        }
++
++        var getDefaultRpcPort = function () {
++            var currentPort = window.location.port;
++
++            if (currentPort) {
++                return currentPort;
++            }
++
++            switch  (getDefaultRpcProtocol()) {
++                case "https":
++                    return "443";
++                case "http":
++                    return "80";
++                default:
++                    return "6800";
++            }
++        }
++
+         var setOptions = function (options) {
+             return ariaNgStorageService.set(ariaNgConstants.optionStorageKey, options);
+         };
+@@ -194,10 +219,8 @@
+ 
+         var initRpcSettingWithDefaultHostAndProtocol = function (setting) {
+             setting.rpcHost = getDefaultRpcHost();
+-
+-            if (isInsecureProtocolDisabled()) {
+-                setting.protocol = ariaNgConstants.defaultSecureProtocol;
+-            }
++            setting.rpcPort= getDefaultRpcPort();
++            setting.protocol = getDefaultRpcProtocol();
+         };
+ 
+         var cloneRpcSetting = function (setting) {
+-- 
+2.41.0
+

--- a/start.sh
+++ b/start.sh
@@ -32,11 +32,6 @@ fi
 
 touch $conf_path/aria2.session
 
-if [[ -n "$ARIA2RPCPORT" ]]; then
-    echo "Changing rpc request port to $ARIA2RPCPORT"
-    sed -i "s/6800/${ARIA2RPCPORT}/g" $ariang_js_path
-fi
-
 userid="$(id -u)" # 65534 - nobody, 0 - root
 groupid="$(id -g)"
 


### PR DESCRIPTION
在这个 docker 镜像中 rpc 的端口应该和
网页的访问端口(不一定是部署端口)是一样的
每次按照部署情况不同去调整不是很优雅，
这里通过给上游AriaNg打补丁的方式实现了，自动适配端口
于是环境变量ARIA2RPCPORT便失去了了作用，所以同时清理了相关代码