### PR TITLE
Fix for RPC SECRET

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@ fi
 
 if [ -n "$RPC_SECRET" ]; then
     sed -i '/^rpc-secret=/d' $conf_path/aria2.conf
-    printf 'rpc-secret=%s\n' "${RPC_SECRET}" >>$conf_path/aria2.conf
+    printf '\nrpc-secret=%s\n' "${RPC_SECRET}" >>$conf_path/aria2.conf
 
     if [ -n "$EMBED_RPC_SECRET" ]; then
         echo "Embedding RPC secret into ariang Web UI"


### PR DESCRIPTION
RPC_SECRET variable is appended at the end of the last line. This modification add a line break before it.